### PR TITLE
feat: set webSettings.domStorageEnabled true

### DIFF
--- a/app/src/main/java/com/fotcamp/finhub/MainActivity.kt
+++ b/app/src/main/java/com/fotcamp/finhub/MainActivity.kt
@@ -38,6 +38,7 @@ class MainActivity : AppCompatActivity() {
             webSettings.loadWithOverviewMode = true
             webSettings.useWideViewPort = true
             webSettings.textZoom = 100;
+            webSettings.domStorageEnabled = true
 
             webView.webViewClient = WebViewClient()
             webView.webChromeClient = WebChromeClient()


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
webview에서 localstorage를 못쓰게 되어져있습니다.

domStorageEnabled default가 false로 되어져있어 추가해주었습니다.
https://developer.android.com/reference/android/webkit/WebSettings#setDomStorageEnabled(boolean)
<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 작업1

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
