### PR TITLE
Fix: fixed alarm permission

### DIFF
--- a/app/src/main/java/com/fotcamp/finhub/WebBridgeHandler.kt
+++ b/app/src/main/java/com/fotcamp/finhub/WebBridgeHandler.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.google.firebase.messaging.FirebaseMessaging
 import org.json.JSONObject
@@ -107,12 +108,17 @@ class WebBridgeHandler(private val context: Context, private val bridgeInterface
     fun requestNotificationPermission(json: JSONObject) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val permission = arrayOf(android.Manifest.permission.POST_NOTIFICATIONS)
-            (context as MainActivity).requestPermissions(permission, MainActivity.PERMISSION_REQUEST_CODE)
-        } else {
-            val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
-                putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            val rationale = ActivityCompat.shouldShowRequestPermissionRationale(context as Activity, android.Manifest.permission.POST_NOTIFICATIONS)
+
+            if (!rationale) {
+                (context as MainActivity).requestPermissions(permission, MainActivity.PERMISSION_REQUEST_CODE)
+                return
             }
-            context.startActivity(intent)
         }
+
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        }
+        context.startActivity(intent)
     }
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [v] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->
API 33 이상에서는 다이얼로그를 띄우는데 한번 유저가 명시적으로 권한을 허용하지 않으면 다이얼로그가 다시 뜨지 않도록 OS에서 막히는 것으로 보입니다.
그래서 다이얼로그를 띄울 수 있는지를 판단하여 다이얼로그 또는 설정화면으로 이동하도록 수정했습니다.

## 관련된 이슈 넘버

<!-- close #1 -->
https://fin-hub.atlassian.net/browse/FIN-116?atlOrigin=eyJpIjoiNWVkOTAzYWFjMzkxNGY2OTg4OTlmYWUyYzFkYTlmMTUiLCJwIjoiaiJ9

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- requestNotificationPermission 호출 시 다이얼로그를 띄울 수 있는지 판단하여 다이얼로그 또는 설정화면으로 이동하도록 수정

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
